### PR TITLE
Documentation changes

### DIFF
--- a/docs/1-introduction.md
+++ b/docs/1-introduction.md
@@ -67,4 +67,4 @@ To reduce costs, you can switch to free SKUs for Azure App Service, Azure Cognit
 > **Warning**
 > To avoid unnecessary costs, remember to destroy your provisioned resources by deleting the resource group.
 
-[Next](/docs/2-provision-azure-resources.md)
+[Next](/docs/3-run-locally.md)

--- a/docs/3-run-locally.md
+++ b/docs/3-run-locally.md
@@ -4,7 +4,7 @@ Clone this repository locally or fork to your Github account. Run all of the the
 
 ## Prerequisites
 
-- **History Database**: If you didn't [provision the Azure resources](2-provision-azure-resources.md), you **must** at least deploy an instance of Cosmos DB in your Azure Subscription to store chat history.
+- **History Database**: If you didn't [provision the Azure resources](README.md#deploy-to-azure) by following one of the deployment options you **must** at least deploy an instance of Cosmos DB in your Azure Subscription to store chat history.
 
 - **Identity Provider**: For local development, you have the option of using a username / password. If you prefer to use an Identity Provider, follow the [instructions](3-run-locally.md) to add one.
 

--- a/docs/3-run-locally.md
+++ b/docs/3-run-locally.md
@@ -4,7 +4,7 @@ Clone this repository locally or fork to your Github account. Run all of the the
 
 ## Prerequisites
 
-- **History Database**: If you didn't [provision the Azure resources](README.md#deploy-to-azure) by following one of the deployment options you **must** at least deploy an instance of Cosmos DB in your Azure Subscription to store chat history.
+- **History Database**: If you didn't [provision the Azure resources](/README.md#deploy-to-azure) by following one of the deployment options you **must** at least deploy an instance of Cosmos DB in your Azure Subscription to store chat history.
 
 - **Identity Provider**: For local development, you have the option of using a username / password. If you prefer to use an Identity Provider, follow the [instructions](3-run-locally.md) to add one.
 


### PR DESCRIPTION
Corrected two references to a missing page `docs/2-provision-azure-resources.md`

In `/docs/1-introduction.md` the **Next** link at bottom of the page
	
In `/docs/3-run-locally.md` the **provisiong the Azure resources** in  the Prerequisites section
